### PR TITLE
Minor changes to ep5 processes part1

### DIFF
--- a/_episodes/05-processes-part1.md
+++ b/_episodes/05-processes-part1.md
@@ -12,6 +12,7 @@ objectives:
 keypoints:
 - "A Nextflow process is an independent task/step in a workflow"
 - "Processes contain up to five definition blocks including, directives, inputs, outputs, when clause and finally a script block."
+- "Processes contain up to five definition blocks including: directives, inputs, outputs, when clause and finally a script block."
 - "The script block contains the commands you would like to run."
 - "Inputs are defined in the input block with a type qualifier and a name."
 ---
@@ -21,22 +22,21 @@ keypoints:
 
 We now know how to create and use Channels to send data around a workflow. We will now see how to run tasks within a workflow using processes.
 
-A `process` is the way Nextflow execute commands you would run on the command line or custom scripts.
 
-Processes can be thought of as a particular task/steps in a workflow, e.g. an alignment step in RNA-Seq analysis. Processes  are independent of each other (don't require another processes to execute) and can not communicate/write to each other . It is the Channels that pass the data from each process to another, and we do this by having the processes define input and output channels.
+A process can be thought of as a particular task/step in a workflow, e.g. an alignment step in RNA-seq analysis. Processes are independent of each other (don't require any another process to execute) and can not communicate/write to each other. Data is passed between processes via input and output Channels.
 
-For example, below is a command you would run to create a index directory for the [salmon](https://salmon.readthedocs.io/en/latest/salmon.html) aligner on the command line:
+For example, below is the command line you would run to create a index for the yeast transcriptome to be used with the [salmon](https://salmon.readthedocs.io/en/latest/salmon.html) aligner:
 
 ~~~
 $ salmon index -t data/yeast/transcriptome/Saccharomyces_cerevisiae.R64-1-1.cdna.all.fa.gz -i data/yeast/salmon_index --kmerLen 31
 ~~~
 {: .language-bash }
 
-Below we will show how to convert this into a simple Nextflow process.
+Now we will show how to convert this into a simple Nextflow process.
 
 ## Process definition
 
-The process definition starts with keyword the `process`, followed by process name `INDEX` and finally the process `body` delimited by curly brackets `{}`. The process body must contain a string  which represents the command or, more generally, a script that is executed by it.
+The process definition starts with keyword `process`, followed by process name, in this case `INDEX`, and finally the process `body` delimited by curly brackets `{}`. The process body must contain a string  which represents the command or, more generally, a script that is executed by it.
 
 ~~~
 process INDEX {
@@ -73,7 +73,7 @@ workflow {
 ~~~
 {: .language-groovy }
 
-We can now run the process
+We can now run the process:
 
 ~~~
 $ nextflow run process_index.nf
@@ -105,8 +105,8 @@ executor >  local (1)
 > >    
 > >   script:
 > >   """
-> >    salmon --version
-> >    """
+> >   salmon --version
+> >   """
 > > }
 > >
 > > workflow {
@@ -134,11 +134,11 @@ executor >  local (1)
 
 The previous example was a simple `process` with no defined inputs and outputs that ran only once. To control inputs, outputs and how a command is executed a process may contain five definition blocks:
 
-1. **directives**: allow the definition of optional settings that affect the execution of the current process e.g. the number of cpus a task uses and the amount of memory allocated.
-1. **inputs**: Define the input dependencies, usually channels, which determines the number of times a process is executed.
-1. **outputs**: Defines the output channels used by the process to send results/data produced by the process.
-1. **when clause**: Allow you to define a condition that must be verified in order to execute the process.
-1. **The script block**: The script block is a statement within quotes that defines the command that is executed by the process to carry out its task.
+1. **directives - 0, 1, or more**: allow the definition of optional settings that affect the execution of the current process e.g. the number of cpus a task uses and the amount of memory allocated.
+1. **inputs - 0, 1, or more**: Define the input dependencies, usually channels, which determines the number of times a process is executed.
+1. **outputs - 0, 1, or more**: Defines the output channels used by the process to send results/data produced by the process.
+1. **when clause - optional**: Allows you to define a condition that must be verified in order to execute the process.
+1. **script block - required**: A statement within quotes that defines the commands that are executed by the process to carry out its task.
 
 
 The syntax is defined as follows:
@@ -157,12 +157,6 @@ process < NAME > {
 }
 ~~~
 {: .language-groovy }
-
-* Zero, one or more process directives, e.g cpus
-* Zero, one or more process inputs
-* Zero, one or more process outputs
-* An optional boolean conditional to trigger the process execution
-* The command to be executed
 
 
 ## Script
@@ -265,7 +259,7 @@ workflow {
 ~~~
 {: .language-groovy }
 
-This allows the the use of a different programming languages which may better fit a particular job. However, for large chunks of code is suggested to save them into separate files and invoke them from the process script.
+This allows the use of a different programming languages which may better fit a particular job. However, for large chunks of code it is suggested to save them into separate files and invoke them from the process script.
 
 ~~~
 nextflow.enable.dsl=2
@@ -284,13 +278,18 @@ workflow {
 ~~~
 {: .language-groovy }
 
+> ## Associated scripts
+> Scripts such as the one in the example above, `myscript.py`, can be stored in a `bin` folder at the same directory level as the Nextflow workflow script that invokes them, and given execute permission. Nextflow will automatically add this folder to the `PATH` environment variable. To invoke the script in a Nextflow process, simply use its filename on its own rather than invoking the interpreter e.g. `myscript.py` instead of `python myscript.py`.
+{: .callout }
+
+
 ### Script parameters
 
 The command in the `script` block can be defined dynamically using Nextflow variables e.g. `${projectDir}`.
 To reference a variable in the script block you can use the `$` in front of the Nextflow variable name, and additionally you can add `{}` around the variable name e.g. `${projectDir}`.
 
 > ##  Variable substitutions
-> Similar to bash scripting Nextflow uses the "$" character to introduces variable substitutions. The variable name to be expanded may be enclosed in braces `{variable_name}`, which are optional but serve to protect the variable to be expanded from characters immediately following it which could be interpreted as part of the name.
+> Similar to bash scripting Nextflow uses the "$" character to introduce variable substitutions. The variable name to be expanded may be enclosed in braces `{variable_name}`, which are optional but serve to protect the variable to be expanded from characters immediately following it which could be interpreted as part of the name. It is a good rule of thumb to always use the `{}` syntax.
 {: .callout }
 
 In the example below the variable `kmer` is set to the value 31 at the top of the Nextflow script.
@@ -348,7 +347,7 @@ workflow {
 ~~~
 {: .language-groovy }
 
-Remember, we can change the default value of `kmer` to 11 by running the Nextflow script using the command below. **Note:** parameter have two hyphens `--` .
+Remember, we can change the default value of `kmer` to 11 by running the Nextflow script using the command below. **Note:** parameters to the workflow have two hyphens `--`.
 
 ~~~
 nextflow run process_script_params.nf --kmer 11
@@ -406,7 +405,7 @@ nextflow run process_script_params.nf --kmer 11
 Nextflow uses the same Bash syntax for variable substitutions, `$variable`, in strings.
 However, Bash variables need to be escaped using `\` character in front of `\$variable` name.
 
-In the example below we will use set the bash variable KMERSIZE to the value of `$params.kmer`.
+In the example below we will set the bash variable `KMERSIZE` to the value of `$params.kmer`, and then use `KMERSIZE` in our script block.
 
 
 ~~~
@@ -438,9 +437,8 @@ Another alternative is to use a `shell` block definition instead of `script`.
 When using the `shell` statement Bash variables are referenced in the normal way `$my_bash_variable`;
 However, the `shell` statement uses a different syntax for Nextflow variable substitutions: `!{nextflow_variable}`, which is needed to use both Nextflow and Bash variables in the same script.
 
-For example in the script below that uses the `shell statment `
-we reference the Nextflow variables as such, `!{projectDir}` and `!{params.kmer}` and the Bash variable
-as `$PWD`.
+For example in the script below that uses the `shell` statement
+we reference the Nextflow variables as `!{projectDir}` and `!{params.kmer`, and the Bash variable as `$PWD`.
 
 ```
 //process_shell.nf
@@ -472,7 +470,7 @@ Sometimes you want to change how a process is run depending on some condition. I
 
 ### If statement
 
-The `if` statement uses the same syntax common other programming lang such Java, C, JavaScript, etc.
+The `if` statement uses the same syntax common to other programming languages such Java, C, JavaScript, etc.
 
 ~~~
 if( < boolean expression > ) {
@@ -488,7 +486,7 @@ else {
 {: .language-groovy }
 
 
-For example, the Nextflow script below will use the `if` statement to change what index is created depending on the Nextflow variable `params.aligner`.
+For example, the Nextflow script below will use the `if` statement to change which index is created depending on the Nextflow variable `params.aligner`.
 
 ~~~
 //process_conditional.nf
@@ -537,15 +535,15 @@ indexed using kallisto
 
 ## Inputs
 
-Processes are isolated from each other but can communicate by sending values and files via Nextflow channels into `input` and `output` blocks.
+Processes are isolated from each other but can communicate by sending values and files via Nextflow channels from `input` and into `output` blocks.
 
 The `input` block defines which channels the process is expecting to receive input from.
-The number of elements in input channels determine the process dependencies and the number of time a process executes.
+The number of elements in input channels determines the process dependencies and the number of times a process executes.
 
 ![Process Flow](../fig/channel-process.png)
 
 
-You can only define one input block at a time and it must contain one or more inputs declarations.
+You can only define one input block at a time and it must contain one or more input declarations.
 
 The input block follows the syntax shown below:
 
@@ -558,7 +556,7 @@ input:
 The input qualifier declares the type of data to be received.
 
 > ## Input qualifiers
-> * `val`: Lets you access the received input value by its name in the process script.
+> * `val`: Lets you access the received input value by its name as a variable in the process script.
 > * `env`: Lets you use the input value to set an environment variable named as the specified input name.
 > * `path`: Lets you handle the received value as a file, staging the file properly in the execution context.
 > * `stdin`: Lets you forward the received value to the process stdin special file.
@@ -607,15 +605,15 @@ processing chromosome 2
 ~~~
 {: .output}
 
-In the above example the process is executed 24 times; each time a value is received from the queue channel `chr_ch` it is used to run process.
+In the above example the process is executed 24 times; each time a value is received from the queue channel `chr_ch` it is used to run the process.
 
 > ## Channel order
-> The channel guarantees that items are delivered in the same order as they have been sent,  but,  since the process is executed in a parallel manner, there is no guarantee that they are processed in the same order as they are received.
+> The channel guarantees that items are delivered in the same order as they have been sent, but since the process is executed in a parallel manner, there is no guarantee that they are processed in the same order as they are received.
 {: .callout}
 
 ### Input files
 
-When you need to handle files as input you need the `path` qualifier. Using the `path` qualifier means that Nextflow will stage it in the process execution directory, and it can be access in the script by using the name specified in the input declaration.
+When you need to handle files as input you need the `path` qualifier. Using the `path` qualifier means that Nextflow will stage it in the process execution directory, and it can be accessed in the script by using the name specified in the input declaration.
 
 The input file name can be defined dynamically by defining the input name as a Nextflow variable and referenced in the script using the  `$variable_name` syntax.
 
@@ -628,6 +626,7 @@ nextflow.enable.dsl=2
 process NUMLINES {
     input:
     path read
+    
     script:
     """
     printf '${read} '
@@ -665,10 +664,8 @@ ref1_2.fq.gz 58708
 ~~~
 {: .output }
 
-<br>
 The input name can also be defined as user specified filename inside quotes.
 For example in the script below the name of the file is specified as `'sample.fq.gz'` in the input definition and can be referenced by that name in the script block.
-<br>
 
 ~~~
 //process_input_file_02.nf
@@ -677,6 +674,7 @@ nextflow.enable.dsl=2
 process NUMLINES {
     input:
     path 'sample.fq.gz'
+    
     script:
     """
     printf 'sample.fq.gz'
@@ -790,7 +788,7 @@ sample.fq.gz58708
 ### Combining input channels
 
 A key feature of processes is the ability to handle inputs from multiple channels.
-However it’s important to understands how the number of items within the multiple channels affect the execution of a process.
+However it’s important to understand how the number of items within the multiple channels affect the execution of a process.
 
 Consider the following example:
 
@@ -870,7 +868,7 @@ $ nextflow run process_combine_02.nf -process.echo
 ~~~
 {: .language-bash }
 
-In the above example the process is executed only two time, because when a queue channel has no more data to be processed it stops the process execution.
+In the above example the process is executed only two times, because when a queue channel has no more data to be processed it stops the process execution.
 
 ~~~
 2 and b
@@ -881,7 +879,7 @@ In the above example the process is executed only two time, because when a queue
 
 ### Value channels and process termination
 
-**Note** however that value channels, `Channel.value` , do not affect the process termination.
+**Note** however that value channels, `Channel.value`, do not affect the process termination.
 
 To better understand this behaviour compare the previous example with the following one:
 
@@ -967,7 +965,7 @@ And include the command below in the script directive
 
 # Input repeaters
 
-We saw previously that by default the number of time a process run is defined by the queue channel with the fewest items. However, the `each` qualifier allows you to repeat the execution of a process for each item in a list or a queue channel, every time new data is received.
+We saw previously that by default the number of times a process runs is defined by the queue channel with the fewest items. However, the `each` qualifier allows you to repeat the execution of a process for each item in a list or a queue channel, every time new data is received.
 
 For example if we can fix the previous example by using the input qualifer `each` for the letters queue channel:
 

--- a/_episodes/05-processes-part1.md
+++ b/_episodes/05-processes-part1.md
@@ -11,7 +11,6 @@ objectives:
 - "Define inputs to a process."
 keypoints:
 - "A Nextflow process is an independent task/step in a workflow"
-- "Processes contain up to five definition blocks including, directives, inputs, outputs, when clause and finally a script block."
 - "Processes contain up to five definition blocks including: directives, inputs, outputs, when clause and finally a script block."
 - "The script block contains the commands you would like to run."
 - "Inputs are defined in the input block with a type qualifier and a name."
@@ -22,6 +21,7 @@ keypoints:
 
 We now know how to create and use Channels to send data around a workflow. We will now see how to run tasks within a workflow using processes.
 
+A `process` is the way Nextflow executes commands you would run on the command line or custom scripts.
 
 A process can be thought of as a particular task/step in a workflow, e.g. an alignment step in RNA-seq analysis. Processes are independent of each other (don't require any another process to execute) and can not communicate/write to each other. Data is passed between processes via input and output Channels.
 

--- a/_episodes/05-processes-part2.md
+++ b/_episodes/05-processes-part2.md
@@ -3,9 +3,9 @@ title: "Processes Part 2"
 teaching: 30
 exercises: 10
 questions:
-- "How do I get data, files and values,  out of processes?"
+- "How do I get data, files, and values,  out of processes?"
 - "How do I handle grouped input and output?"
-- "How do can I control when a process is executed?"
+- "How can I control when a process is executed?"
 - "How do I control resources, such as number of CPUs and memory, available to processes?"
 - "How do I save output/results from a process?"
 objectives:
@@ -23,11 +23,11 @@ keypoints:
 
 ## Outputs
 
-We have seen how to input data into a process now we will see how to output files and values from a process.
+We have seen how to input data into a process; now we will see how to output files and values from a process.
 
 The `output` declaration block allows us to define the channels used by the process to send out the files and values produced.
 
-An output block is not required, but if it is present it can contain one or more outputs declarations.
+An output block is not required, but if it is present it can contain one or more output declarations.
 
 The output block follows the syntax shown below:
 
@@ -47,7 +47,7 @@ Like the input, the type of output data is defined using type qualifiers.
 The `val` qualifier allows us to output a value defined in the script.
 
 
-Because Nextflow processes can only communicate through channels if we want to share a value input into one process as input to another process we would need to define that value in the output declaration block as shown in the following example:
+Because Nextflow processes can only communicate through channels, if we want to share a value input into one process as input to another process we would need to define that value in the output declaration block as shown in the following example:
 
 
 ~~~
@@ -185,11 +185,11 @@ Analysis complete for ref1_1.fq.gz
 
 * Input files are not included in the list of possible matches.
 * Glob pattern matches against both files and directories path.
-* When a two stars pattern `**` is used to recourse across directories, only file paths are matched i.e. directories are not included in the result list.
+* When a two stars pattern `**` is used to recurse through subdirectories, only file paths are matched i.e. directories are not included in the result list.
 
 
 > ## Output channels
-> Modify the nextflow script `process_exercise_output.nf` to include an output blocks that captures the different index folders `index_$kmer`.
+> Modify the nextflow script `process_exercise_output.nf` to include an output block that captures the different index folders `index_$kmer`.
 > Use the `view` operator on the output channel.
 > ~~~
 > //process_exercise_output.nf
@@ -247,13 +247,13 @@ Analysis complete for ref1_1.fq.gz
 
 So far we have seen how to declare multiple input and output channels, but each channel was handling only one value at time. However Nextflow can handle groups of values using the `tuple` qualifiers.
 
-In tuples the first item is the grouping key and the second item is the list of files.
+In tuples the first item is the grouping key and the second item is the list.
 
 ~~~
 [group_key,[file1,file2,...]]
 ~~~
 
-When using channel containing a tuple, the corresponding input declaration must be declared with a `tuple` qualifier, followed by definition of each item in the tuple.
+When using a channel containing a tuple, the corresponding input declaration must be declared with a `tuple` qualifier, followed by definition of each item in the tuple.
 
 ~~~
 //process_tuple_input.nf
@@ -286,10 +286,10 @@ ref1_1.fq.gz ref1_2.fq.gz
 ~~~
 {: .output }
 
-In the same manner output channel emitting tuple of values can be declared using the `tuple` qualifier following by the definition of each tuple element in the tuple.
+In the same manner an output channel emitting tuple of values can be declared using the `tuple` qualifier following by the definition of each tuple element in the tuple.
 
 In the code snippet below the output channel would contain a tuple with
-the grouping key value as the Nextflow variable `sample_id` and a single `"${sample_id}_salmon_output"` directory stored as a tuple.
+the grouping key value as the Nextflow variable `sample_id` and a single item list containing the `"${sample_id}_salmon_output"` directory.
 
 ~~~
 output:
@@ -507,13 +507,13 @@ The above process uses the three directives, `tag`, `cpus` and `echo`.
 
 The `tag` directive to allow you to give a custom tag to each process execution. This tag makes it easier to identify a particular instance of a process in a log file or in the execution report.
 
-The second directive  `cpus`  allows you to define the number of CPU required for each of the process’ task.
+The second directive  `cpus`  allows you to define the number of CPUs required for each of the process’ task.
 
 The third directive `echo true` prints the stdout to the terminal.
 
-We also uses the Nextflow `task.cpus` variable to capture the number of cpus assigned to a task.
+We use the Nextflow `task.cpus` variable to capture the number of cpus assigned to a task. This is frequently used to specify the number of threads in a multi-threaded command in the script block.
 
-Another commonly used directive is memory specification `memory`.
+Another commonly used directive is memory specification: `memory`.
 
 A complete list of directives is available at this [link](https://www.nextflow.io/docs/latest/process.html#directives).
 
@@ -593,11 +593,13 @@ A complete list of directives is available at this [link](https://www.nextflow.i
 
 ### PublishDir directive
 
-Nextflow manages intermediate results from the pipelines expected outputs independently.
+Nextflow manages intermediate results from the pipeline's expected outputs independently.
 
-Files created by a `process` are stored in a task specific working directory which is considered as a temporary. Normally this is under the `work` directory , that can be deleted upon completion.
+Files created by a `process` are stored in a task specific working directory which is considered as temporary. Normally this is under the `work` directory, which can be deleted upon completion.
 
 The files you want the workflow to return as results need to be defined in the `process` `output` block and then the output directory specified using the `directive` `publishDir`. More information [here](https://www.nextflow.io/docs/latest/process.html#publishdir).
+
+**Note:** A common mistake is to specify an output directory in the `publishDir` directive while forgetting to specify the files you want to include in the `output` block.
 
 ~~~
 publishDir <directory>, parameter: value, parameter2: value ...
@@ -667,7 +669,7 @@ results/
 {: .output }
 
 
-In the above example, the `publishDir "results/quant"`,  create a symbolic link `->` to the output files specified by the process `salmon_quant` to the directory path `results/quant`.
+In the above example, the `publishDir "results/quant"`,  creates a symbolic link `->` to the output files specified by the process `salmon_quant` to the directory path `results/quant`.
 
 > ## publishDir
 > The publishDir output is relative to the directory of the main Nextflow script.
@@ -675,7 +677,7 @@ In the above example, the `publishDir "results/quant"`,  create a symbolic link 
 
 ### publishDir parameters
 
-The `publishDir` directive can take optional parameters, for example the `mode` parameter can take the value `"copy"` to specify that you wish to copy the file to output directory rather than just a symbolic link to the files in the working directory.
+The `publishDir` directive can take optional parameters, for example the `mode` parameter can take the value `"copy"` to specify that you wish to copy the file to output directory rather than just a symbolic link to the files in the working directory. Since the working directory is generally deleted on completion of a pipeline, it is safest to use `mode: "copy"` for results files. The default of creating symbolic links is helpful for checking intermediate files which are not needed longer term.
 ~~~
 publishDir "results/quant", mode: "copy"
 ~~~
@@ -846,7 +848,7 @@ results/
 {: .challenge}
 
 > ## Nextflow Patterns
-> If you want to find out common structures of Nextflow process the [Nextflow Patterns page](http://nextflow-io.github.io/patterns/) collects some recurrent implementation patterns used in Nextflow applications.
+> If you want to find out common structures of Nextflow processes, the [Nextflow Patterns page](http://nextflow-io.github.io/patterns/) collects some recurrent implementation patterns used in Nextflow applications.
 {: .callout}
 
 


### PR DESCRIPTION
@ggrimes 

part1:
//process_script_params.nf - did you intend to show a template for the solution?

part2:
Example in output values

workflow {
  METHOD(methods_ch)
  // use the view operator to display contents of the channel
  METHOD.out.view({ "Received: $it" })
}

Did you want to introduce the closure with extra text here? METHOD.out.view() works fine. Same for process_output_file.nf example.

